### PR TITLE
feat: Add unit test for _tool_dict function

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -75,4 +75,35 @@ async def test_call_tool():
     
     if isinstance(result, dict) and result.get("type") == "error":
         assert "code" in result, "Error response missing code"
-        assert "message" in result, "Error response missing message" 
+        assert "message" in result, "Error response missing message"
+
+
+def test_tool_dict():
+    """Test the _tool_dict function for correct dictionary formatting."""
+    from jarbas.tools import _tool_dict
+    from typing import NamedTuple, Dict, Any
+
+    # Define a mock Tool object
+    class MockTool(NamedTuple):
+        name: str
+        description: str
+        inputSchema: Dict[str, Any]
+
+    # Create a sample tool instance
+    sample_tool = MockTool(
+        name="sample_tool",
+        description="This is a sample tool.",
+        inputSchema={"type": "object", "properties": {"test_param": {"type": "integer"}}}
+    )
+    server_name = "mock_server"
+
+    # Call the _tool_dict function
+    result = _tool_dict(server_name, sample_tool)
+
+    # Assert the structure and content of the returned dictionary
+    assert result["type"] == "function"
+    assert "function" in result
+    function_dict = result["function"]
+    assert function_dict["name"] == f"{server_name}.{sample_tool.name}"
+    assert function_dict["description"] == sample_tool.description
+    assert function_dict["parameters"] == sample_tool.inputSchema


### PR DESCRIPTION
Added a new unit test `test_tool_dict` to `tests/test_tools.py` to specifically verify the behavior of the private `_tool_dict` function in `jarbas/tools.py`.

This function is responsible for formatting tool information into a standard dictionary structure. The new test ensures that:
- The top-level "type" is "function".
- The nested "function" dictionary contains the correct "name" (prefixed with server_name), "description", and "parameters" (matching the inputSchema of the tool).

A `MockTool` named tuple was introduced in the test to simulate the structure of a `Tool` object for isolated testing.

I ran all tests, and the new test passes. The known unrelated failures in LLM-dependent tests persist.